### PR TITLE
Study definition endpoint

### DIFF
--- a/R/study-define.R
+++ b/R/study-define.R
@@ -132,4 +132,6 @@ define_study <- function(name, identifier, arms,
       })
     }
   })
+
+  study_id
 }


### PR DESCRIPTION
Requires merging #18 first.

Implements `define_study()` and `POST /study` with asserts and docs, but without tests just yet.