### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -31,7 +31,12 @@ jobs:
             libfontconfig1-dev \
             libfreetype6-dev \
             libharfbuzz-dev \
-            libfribidi-dev
+            libfribidi-dev \
+            libpng-dev \
+            libjpeg-dev \
+            libtiff5-dev \
+            zlib1g-dev \
+            libbz2-dev
 
       - uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,29 @@ jobs:
           r-version: '4.2.3'
           use-public-rspm: true
 
+      - name: Install system dependencies for systemfonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            fontconfig \
+            libfontconfig1 \
+            pkg-config \
+            libfontconfig1-dev \
+            libfreetype6 \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libpng-dev \
+            libpng16-16 \
+            libjpeg-dev \
+            libtiff5-dev \
+            zlib1g-dev \
+            libbz2-dev
+
+      - name: Ensure pkg-config can find installed libraries
+        run: |
+          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig" >> $GITHUB_ENV
+
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Install CI extras (lintr, cyclocomp)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,6 +30,21 @@ jobs:
           use-public-rspm: true
           install-pandoc: true
 
+      - name: Install system dependencies for systemfonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libpng-dev \
+            libjpeg-dev \
+            libtiff5-dev \
+            zlib1g-dev \
+            libbz2-dev
+
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Install CI extras (pkgdown)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -42,6 +42,21 @@ jobs:
           r-version: '4.2.3'
           use-public-rspm: true
 
+      - name: Install system dependencies for systemfonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libpng-dev \
+            libjpeg-dev \
+            libtiff5-dev \
+            zlib1g-dev \
+            libbz2-dev
+
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Install CI extras (covr)


### PR DESCRIPTION
- add complete system dependencies for systemfonts and ragg packages- Add font libraries (libfontconfig1-dev, libfreetype6-dev, etc.) for systemfonts
- Add image libraries (libpng-dev, libjpeg-dev, libtiff5-dev, etc.) for ragg
- Add PKG_CONFIG_PATH export for lint workflow
- Fixes CI failures on all workflows after PR #107 merge